### PR TITLE
Feature precise location updates

### DIFF
--- a/app/src/main/java/com/example/flickrgallery/gps/GpsProvider.kt
+++ b/app/src/main/java/com/example/flickrgallery/gps/GpsProvider.kt
@@ -53,9 +53,8 @@ class GpsProvider(context: Context) {
 
     @SuppressLint("MissingPermission")
     fun setAccurateLocationListener(onLocationUpdated: (GpsSnapshot) -> Unit) {
-        val locationCallback = getLocationCallback(onLocationUpdated)
         fusedLocationClient.requestLocationUpdates(
-                getLocationRequest(), locationCallback, null
+                getLocationRequest(), getLocationCallback(onLocationUpdated), null
         )
     }
 

--- a/app/src/main/java/com/example/flickrgallery/gps/GpsProvider.kt
+++ b/app/src/main/java/com/example/flickrgallery/gps/GpsProvider.kt
@@ -17,7 +17,7 @@ class GpsProvider(context: Context) {
 
     companion object {
         private const val ACCEPTABLE_MINIMUM_LOCATION_ACCURACY = 10
-        private const val SECONDS_TO_UPDATE_LOCATION = 5 * 1000L
+        private const val SECONDS_TO_UPDATE_LOCATION = 1 * 1000L
     }
 
     private val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)

--- a/app/src/main/java/com/example/flickrgallery/repo/GpsRepo.kt
+++ b/app/src/main/java/com/example/flickrgallery/repo/GpsRepo.kt
@@ -5,4 +5,5 @@ import com.example.flickrgallery.model.GpsSnapshot
 
 interface GpsRepo {
     suspend fun getActualPosition(): GpsSnapshot
+    fun setAccurateLocationListener(onLocationUpdated: (GpsSnapshot) -> Unit)
 }

--- a/app/src/main/java/com/example/flickrgallery/repo/GpsRepoImpl.kt
+++ b/app/src/main/java/com/example/flickrgallery/repo/GpsRepoImpl.kt
@@ -8,10 +8,15 @@ import kotlinx.coroutines.withContext
 
 class GpsRepoImpl(private val gpsProvider: GpsProvider) : GpsRepo {
 
-
     override suspend fun getActualPosition(): GpsSnapshot {
         return withContext(Dispatchers.IO) {
             gpsProvider.getActualLocation()
+        }
+    }
+
+    override fun setAccurateLocationListener(onLocationUpdated: (GpsSnapshot) -> Unit) {
+        gpsProvider.setAccurateLocationListener {
+            onLocationUpdated(it)
         }
     }
 }

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -70,10 +70,10 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
     private fun setListeners() {
         setOnNavigationItemSelectedListener()
         setStoreLocationFabOnClickListener()
-        requestLocationPermissionsAndLoadExploreTab()
+        requestLocationPermissionsSoExploreFragmentIsLoadedWithPhotos()
     }
 
-    private fun requestLocationPermissionsAndLoadExploreTab() {
+    private fun requestLocationPermissionsSoExploreFragmentIsLoadedWithPhotos() {
         requestPermissionLauncherToGetLocation.launch(Manifest.permission.ACCESS_FINE_LOCATION)
         viewModel.photos.observe(this) {
             if (it.isNotEmpty()) {

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -64,7 +64,17 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
     private fun setListeners() {
         setOnNavigationItemSelectedListener()
         setStoreLocationFabOnClickListener()
+        setProgressVisibleObserver()
         requestLocationPermissionsSoExploreFragmentIsLoadedWithPhotos()
+    }
+
+    private fun setProgressVisibleObserver() {
+        viewModel.progressVisible.observe(this) {
+            binding.progressVisibleLayout.visibility = when(it) {
+                true -> View.VISIBLE
+                false -> View.GONE
+            }
+        }
     }
 
     private fun requestLocationPermissionsSoExploreFragmentIsLoadedWithPhotos() {

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -70,10 +70,7 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
 
     private fun setProgressVisibleObserver() {
         viewModel.progressVisible.observe(this) {
-            binding.progressVisibleLayout.visibility = when(it) {
-                true -> View.VISIBLE
-                false -> View.GONE
-            }
+            binding.progressVisibleLayout.visibility = if(it) View.VISIBLE else View.GONE
         }
     }
 

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -159,7 +159,7 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
     private fun getLocationCallback() = object : LocationCallback() {
         override fun onLocationResult(locationResult: LocationResult) {
             for (location in locationResult.locations) {
-                if (shouldUpdateLocation(location)) {
+                if (isLocationAccurateEnough(location)) {
                     currentLocation = location
                     lifecycleScope.launch(Dispatchers.IO) {
                         viewModel.setPhotosAt(location.latitude, location.longitude)
@@ -169,7 +169,7 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
         }
     }
 
-    private fun shouldUpdateLocation(location: Location?): Boolean {
+    private fun isLocationAccurateEnough(location: Location?): Boolean {
         return location != null && location.accuracy < ACCEPTABLE_MINIMUM_LOCATION_ACCURACY
     }
 

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
     }
 
     private fun setLocationListenerToObtainInitialPhotos() {
-        val gpsProvider =  GpsProvider(this)
+        val gpsProvider = GpsProvider(this)
         val gpsRepo = GpsRepoImpl(gpsProvider)
         gpsRepo.setAccurateLocationListener {
             lifecycleScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -19,7 +19,6 @@ import com.example.flickrgallery.model.StoredLocation
 import com.example.flickrgallery.repo.GpsRepoImpl
 import com.example.flickrgallery.repo.LocalRepoImpl
 import com.example.flickrgallery.repo.StoredLocationRepoImpl
-import com.google.android.gms.location.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -120,8 +120,6 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
                 val database = Db.getDatabase(applicationContext)
                 val storedLocationRepo = StoredLocationRepoImpl(database)
 
-                viewModel.setPhotosAt(it.latitude, it.longitude)
-
                 val newStoredLocation = StoredLocation().apply {
                     latitude = it.latitude
                     longitude = it.longitude

--- a/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainActivity.kt
@@ -77,10 +77,8 @@ class MainActivity : AppCompatActivity(), MainActivityCommunicator {
     private fun requestLocationPermissionsSoExploreFragmentIsLoadedWithPhotos() {
         requestPermissionLauncherToGetLocation.launch(Manifest.permission.ACCESS_FINE_LOCATION)
         viewModel.photos.observe(this) {
-            if (it.isNotEmpty()) {
-                binding.bottomNavigation.selectedItemId = R.id.nav_explore
-                viewModel.photos.removeObservers(this@MainActivity)
-            }
+            binding.bottomNavigation.selectedItemId = R.id.nav_explore
+            viewModel.photos.removeObservers(this@MainActivity)
         }
     }
 

--- a/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
@@ -17,10 +17,6 @@ class MainViewModel(private val localRepo: LocalRepo) : ViewModel() {
     val photos: LiveData<List<Photo>>
         get() = _photos
 
-    init {
-        _progressVisible.value = true
-    }
-
     suspend fun setPhotosAt(latitude: Double, longitude: Double) {
         _progressVisible.postValue(true)
         _photos.postValue(getPhotos(latitude, longitude))

--- a/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
@@ -9,20 +9,31 @@ import com.example.flickrgallery.repo.LocalRepo
 
 class MainViewModel(private val localRepo: LocalRepo) : ViewModel() {
 
+    private val _progressVisible = MutableLiveData<Boolean>()
+    val progressVisible: LiveData<Boolean>
+        get() = _progressVisible
+
     private val _photos = MutableLiveData<List<Photo>>()
     val photos: LiveData<List<Photo>>
         get() = _photos
 
     init {
+        _progressVisible.value = true
         _photos.value = ArrayList()
     }
 
     suspend fun setPhotosAt(latitude: Double, longitude: Double) {
+        _progressVisible.postValue(true)
+        _photos.postValue(getPhotos(latitude, longitude))
+        _progressVisible.postValue(false)
+    }
+
+    private suspend fun getPhotos(latitude: Double, longitude: Double): List<Photo> {
         val wayPointPhotosResult = FlickrApiClient.service.listPhotosNearLocation(latitude, longitude)
         val wayPointPhotos = wayPointPhotosResult.photos.photo
 
         localRepo.insertAllPhotos(wayPointPhotos)
 
-        this._photos.postValue(wayPointPhotos)
+        return wayPointPhotos
     }
 }

--- a/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
@@ -1,7 +1,28 @@
 package com.example.flickrgallery.ui
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.flickrgallery.client.FlickrApiClient
+import com.example.flickrgallery.model.Photo
 import com.example.flickrgallery.repo.LocalRepo
 
 class MainViewModel(private val localRepo: LocalRepo) : ViewModel() {
+
+    private val _photos = MutableLiveData<List<Photo>>()
+    val photos: LiveData<List<Photo>>
+        get() = _photos
+
+    init {
+        _photos.value = ArrayList()
+    }
+
+    suspend fun setPhotosAt(latitude: Double, longitude: Double) {
+        val wayPointPhotosResult = FlickrApiClient.service.listPhotosNearLocation(latitude, longitude)
+        val wayPointPhotos = wayPointPhotosResult.photos.photo
+
+        localRepo.insertAllPhotos(wayPointPhotos)
+
+        this._photos.postValue(wayPointPhotos)
+    }
 }

--- a/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/flickrgallery/ui/MainViewModel.kt
@@ -19,7 +19,6 @@ class MainViewModel(private val localRepo: LocalRepo) : ViewModel() {
 
     init {
         _progressVisible.value = true
-        _photos.value = ArrayList()
     }
 
     suspend fun setPhotosAt(latitude: Double, longitude: Double) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,8 +20,6 @@
 
         <RelativeLayout
             android:id="@+id/progress_visible_layout"
-            android:visibility="gone"
-            tools:visibility="visible"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:orientation="vertical"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,6 +18,26 @@
 
         </androidx.fragment.app.FragmentContainerView>
 
+        <RelativeLayout
+            android:id="@+id/progress_visible_layout"
+            android:visibility="gone"
+            tools:visibility="visible"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+                <ProgressBar
+                    android:layout_centerInParent="true"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:indeterminate="true"
+                    style="?android:attr/progressBarStyleHorizontal"/>
+
+        </RelativeLayout>
+
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottom_navigation"
             android:layout_width="match_parent"


### PR DESCRIPTION
Este PR es para #23 y básicamente cambia la forma en que se obtiene la localización.

Ahora hay un listener que obtiene cada 5s la localización del GPS y una vez obtiene una localización con una precisión lo suficientemente buena, mira de cargar el ExploreFragment.

Si no se acepta el permiso de acceder a la localización al arrancar la app, no se podrá acceder a dicha funcionalidad. Esto podríamos mejorarlo, mediante un AlertDialog si queréis :) De forma que se pueda reintentar.

@ImanolOlveira verás que me he petado el acceso al GpsRepo y GpsProvider. Mi intención es actualizarlos con estos cambios, pero para ello tengo que hacer más pruebas, ya que no he logrado hacerlo.