### PR TITLE
Fix GpsProvider so it only sends locations with high accuracy and prevents issues with Android Emulators

### DIFF
--- a/app/src/main/java/com/example/flickrgallery/gps/GpsProvider.kt
+++ b/app/src/main/java/com/example/flickrgallery/gps/GpsProvider.kt
@@ -3,7 +3,6 @@ package com.example.flickrgallery.gps
 import android.annotation.SuppressLint
 import android.content.Context
 import android.location.Location
-import com.example.flickrgallery.BuildConfig
 import com.example.flickrgallery.model.GpsSnapshot
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
@@ -56,10 +55,6 @@ class GpsProvider(context: Context) {
     }
 
     private fun isLocationAccurateEnough(location: Location?): Boolean {
-        return if (BuildConfig.DEBUG){
-            true
-        } else{
-            location != null && location.accuracy < ACCEPTABLE_MINIMUM_LOCATION_ACCURACY
-        }
+        return location != null && location.accuracy < ACCEPTABLE_MINIMUM_LOCATION_ACCURACY
     }
 }


### PR DESCRIPTION
@ImanolOlveira por lo visto, el problema con la actualización de las localizaciones era esta función. Al devolver siempre true cuando la build es DEBUG, devolvía la primera localización a mano que tiene el dispositivo, pero que realmente ya no es válida. De ahí la necesidad de ver de aceptar localizaciones con una gran precisión.